### PR TITLE
LF: preview markdown files

### DIFF
--- a/modules/home-manager/lf.nix
+++ b/modules/home-manager/lf.nix
@@ -20,6 +20,7 @@
             application/x-rar) "${pkgs.unrar}/bin/unrar" l "$1"  ;;
             application/x-tar) "${pkgs.gnutar}/bin/tar" -tf "$1" ;;
             application/json)  "${pkgs.jq}/bin/jq" --color-output . "$1" ;;
+            text/markdown)     "${pkgs.glow}/bin/glow" "$1" ;;
             *)                 "${pkgs.bat}/bin/bat" --color always "$1" ;;
           esac
         '';


### PR DESCRIPTION
This PR configures LF to use [Glow](https://github.com/charmbracelet/glow) to preview markdown files.

## Current problems:

The command `file --dereference --brief --mime-type -- "${1}"` is returning `text/plain` instead of `text/markdown`.