### PR TITLE
Hyprland: Fix binding conflict between `exec, hyprlock` and `movewindow, r`

### DIFF
--- a/modules/home-manager/desktop/hyprland.nix
+++ b/modules/home-manager/desktop/hyprland.nix
@@ -40,7 +40,7 @@ in {
           "$mod, return, exec, $terminal"
           "$mod, d, exec, $menu"
           "$mod, space, exec, $menu"
-          "$mod SHIFT, l, exec, ${config.jpcenteno-home.desktop.hyprland.hyprlock.command}"
+          "$mod, escape, exec, ${config.jpcenteno-home.desktop.hyprland.hyprlock.command}"
 
           "$mod, h, movefocus, l"
           "$mod, j, movefocus, d"


### PR DESCRIPTION
Both `exec hyprlock` and `movewindow, r` where mapped to `MOD+S+l` which caused both actions to trigger at the same time.

This PR remaps the `exec hyprlock` binding to `MOD+Escape` solving the problem and improving ergonomics while we are at it.