### PR TITLE
Zathura: Set as default opener for new cbz, cbr mime types

### DIFF
--- a/modules/home-manager/desktop/apps/zathura.nix
+++ b/modules/home-manager/desktop/apps/zathura.nix
@@ -33,6 +33,9 @@ in {
         "application/x-cbz" = [ "org.pwmt.zathura-cb.desktop" ];
         "application/x-cb7" = [ "org.pwmt.zathura-cb.desktop" ];
         "application/x-cbt" = [ "org.pwmt.zathura-cb.desktop" ];
+        "application/vnd.comicbook-rar" = [ "org.pwmt.zathura-cb.desktop" ];
+        "application/vnd.comicbook+zip" = [ "org.pwmt.zathura-cb.desktop" ];
+
 
         "image/vnd.djvu" = [ "org.pwmt.zathura-djvu.desktop" ];
         "image/vnd.djvu+multipage" = [ "org.pwmt.zathura-djvu.desktop" ];


### PR DESCRIPTION
It seems that the mime types for `.cbz` and `.cbr` have changed from `application/x-cbz` and `application/x-cbr` to `application/vnd.comicbook-rar` and `application/vnd.comicbook+zip` respectively breaking my workflow.

This PR fixes the issue making zathura the default opener once again. 