### PR TITLE
Chromium: Add optional enableWideVine override

### DIFF
--- a/modules/home-manager/desktop/apps/chromium.nix
+++ b/modules/home-manager/desktop/apps/chromium.nix
@@ -47,6 +47,12 @@ in
       default = "ungoogled-chromium";
     };
 
+    enableWideVine = lib.mkOption {
+      type = lib.types.bool;
+      description = "Enable WideVine";
+      default = true;
+    };
+
     # FIXME autodetect ungoogled chromium or throw a warning, IDK.
     enableUngoogledChromiumFlags = lib.mkEnableOption "Ungoogled-chromium specific flags";
   };
@@ -55,7 +61,7 @@ in
     {
       programs.chromium = {
         enable = true;
-        package = cfg.package;
+        package = (cfg.package.override { enableWideVine = cfg.enableWideVine; });
         # FIXME this will break non-Wayland or non PipeWire hosts.
         commandLineArgs = lib.concatLists [
           [


### PR DESCRIPTION
CLOSES #68

## Notes

I tried the `override { enableWideVine = true; }` thing [mentioned on the NixOS wiki](https://wiki.nixos.org/wiki/Chromium) but it didn't work.

**Note 2024-12-26** This is still not working for `ungoogled-chromium`. I decided to backlog it as it's not worth my time right now. (Also, fuck DRM).