### PR TITLE
git: Make git-push default to default origin and same branch

### DIFF
--- a/dotfiles/git/config
+++ b/dotfiles/git/config
@@ -32,6 +32,10 @@
     current-branch = rev-parse --abbrev-ref HEAD
     current-commit = rev-parse --verify HEAD
 
+[push]
+    default = current # Push to branch with same name on the remote.
+    autoSetupRemote = true # Use default upstream.
+
 # ╔════════════════════════════════════════════════════════════════════════╗
 # ║ Commit signing                                                         ║
 # ╚════════════════════════════════════════════════════════════════════════╝


### PR DESCRIPTION
This PR configures `git-push` to use the default remote and a branch with the
same name

```
+[push]
+    default = current # Push to branch with same name on the remote.
+    autoSetupRemote = true # Use default upstream.
```
