### PR TITLE
Remove flake inputs [refactor]

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,44 +16,9 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1727348695,
-        "narHash": "sha256-J+PeFKSDV+pHL7ukkfpVzCOO7mBSrrpJ3svwBFABbhI=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "1925c603f17fc89f4c8f6bf6f631a802ad85d784",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
-        "zen-browser": "zen-browser"
-      }
-    },
-    "zen-browser": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_2"
-      },
-      "locked": {
-        "lastModified": 1736786734,
-        "narHash": "sha256-kf3z4HTTuVPt8WI4ky7OmDxp6jpqNdtJ3UIzeqt9MP4=",
-        "owner": "jpcenteno",
-        "repo": "zen-browser-flake",
-        "rev": "efba4feb49c3f0d237799ca5f5ddcdb7c47c05d8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "jpcenteno",
-        "repo": "zen-browser-flake",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -16,27 +16,6 @@
         "type": "github"
       }
     },
-    "home-manager": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1719827415,
-        "narHash": "sha256-pvh+1hStXXAZf0sZ1xIJbWGx4u+OGBC1rVx6Wsw0fBw=",
-        "owner": "nix-community",
-        "repo": "home-manager",
-        "rev": "f2e3c19867262dbe84fdfab42467fc8dd83a2005",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "ref": "release-23.11",
-        "repo": "home-manager",
-        "type": "github"
-      }
-    },
     "nix-colors": {
       "inputs": {
         "base16-schemes": "base16-schemes",
@@ -105,7 +84,6 @@
     },
     "root": {
       "inputs": {
-        "home-manager": "home-manager",
         "nix-colors": "nix-colors",
         "nixpkgs": "nixpkgs",
         "zen-browser": "zen-browser"

--- a/flake.lock
+++ b/flake.lock
@@ -1,40 +1,5 @@
 {
   "nodes": {
-    "base16-schemes": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696158499,
-        "narHash": "sha256-5yIHgDTPjoX/3oDEfLSQ0eJZdFL1SaCfb9d6M0RmOTM=",
-        "owner": "tinted-theming",
-        "repo": "base16-schemes",
-        "rev": "a9112eaae86d9dd8ee6bb9445b664fba2f94037a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "tinted-theming",
-        "repo": "base16-schemes",
-        "type": "github"
-      }
-    },
-    "nix-colors": {
-      "inputs": {
-        "base16-schemes": "base16-schemes",
-        "nixpkgs-lib": "nixpkgs-lib"
-      },
-      "locked": {
-        "lastModified": 1707825078,
-        "narHash": "sha256-hTfge2J2W+42SZ7VHXkf4kjU+qzFqPeC9k66jAUBMHk=",
-        "owner": "misterio77",
-        "repo": "nix-colors",
-        "rev": "b01f024090d2c4fc3152cd0cf12027a7b8453ba1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "misterio77",
-        "repo": "nix-colors",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1720535198,
@@ -48,21 +13,6 @@
         "owner": "NixOS",
         "ref": "nixos-23.11",
         "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-lib": {
-      "locked": {
-        "lastModified": 1697935651,
-        "narHash": "sha256-qOfWjQ2JQSQL15KLh6D7xQhx0qgZlYZTYlcEiRuAMMw=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "e1e11fdbb01113d85c7f41cada9d2847660e3902",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
         "type": "github"
       }
     },
@@ -84,7 +34,6 @@
     },
     "root": {
       "inputs": {
-        "nix-colors": "nix-colors",
         "nixpkgs": "nixpkgs",
         "zen-browser": "zen-browser"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -87,22 +87,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-unstable": {
-      "locked": {
-        "lastModified": 1722062969,
-        "narHash": "sha256-QOS0ykELUmPbrrUGmegAUlpmUFznDQeR4q7rFhl8eQg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b73c2221a46c13557b1b3be9c2070cc42cf01eb3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1727348695,
@@ -124,7 +108,6 @@
         "home-manager": "home-manager",
         "nix-colors": "nix-colors",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-unstable": "nixpkgs-unstable",
         "zen-browser": "zen-browser"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,6 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
-    nix-colors.url = "github:misterio77/nix-colors";
     zen-browser.url = "github:jpcenteno/zen-browser-flake";
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,6 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
-    zen-browser.url = "github:jpcenteno/zen-browser-flake";
   };
 
   outputs = {
@@ -23,7 +22,7 @@
     };
 
     homeManagerModules = {
-      default = import ./modules/home-manager self;
+      default = import ./modules/home-manager;
       hello = import ./modules/home-manager/hello.nix;
       alacritty = import ./modules/home-manager/alacritty.nix;
       brave-browser = import ./modules/home-manager/desktop/apps/brave.nix;

--- a/flake.nix
+++ b/flake.nix
@@ -3,13 +3,6 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
-
-    home-manager = {
-      # Important: Specify branch following same release as nixpkgs.
-      url = "github:nix-community/home-manager/release-23.11";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-
     nix-colors.url = "github:misterio77/nix-colors";
     zen-browser.url = "github:jpcenteno/zen-browser-flake";
   };

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,6 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
-    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     home-manager = {
       # Important: Specify branch following same release as nixpkgs.
@@ -18,15 +17,10 @@
   outputs = {
     self,
     nixpkgs,
-    nixpkgs-unstable,
     ...
   } @ inputs: let
     system = "x86_64-linux";
     pkgs = nixpkgs.legacyPackages.${system};
-    pkgs-unstable = import nixpkgs-unstable {
-      system = "${system}";
-      config = {allowUnfree = true;};
-    };
   in {
     formatter."${system}" = pkgs.alejandra;
 

--- a/modules/home-manager/default.nix
+++ b/modules/home-manager/default.nix
@@ -1,4 +1,4 @@
-self: {
+{
   config,
   lib,
   nix-colors,
@@ -8,7 +8,7 @@ self: {
 in {
   imports = [
     ./shell/default.nix
-    (import ./desktop/hyprland.nix self)
+    ./desktop/hyprland.nix
     ./utils/default.nix
     ./system/default.nix
     ./xdg.nix

--- a/modules/home-manager/desktop/apps/default.nix
+++ b/modules/home-manager/desktop/apps/default.nix
@@ -1,4 +1,4 @@
-self: {
+{
   config,
   lib,
   pkgs,
@@ -12,7 +12,7 @@ in {
     ./chromium.nix
     ./imv.nix
     ./keepasxc.nix
-    (import ./zen-browser.nix self)
+    ./zen-browser.nix
 
     # FIXME 2024-12-07 Uncomment once I fix the issue with the activation script
     # that sets the flatpack remotes.

--- a/modules/home-manager/desktop/apps/zen-browser.nix
+++ b/modules/home-manager/desktop/apps/zen-browser.nix
@@ -1,4 +1,4 @@
-self: {
+{
   config,
   lib,
   pkgs,
@@ -8,11 +8,12 @@ self: {
 in {
   options.jpcenteno-home.desktop.apps.zen-browser = {
     enable = lib.mkEnableOption "Zen Browser";
+    # As of v24.05, Zen Browser is not a part of `nixpkgs`. This flake delegates
+    # the responsibility of providing the right package to the module's user.
+    package = lib.mkPackageOption pkgs "zen" {};
   };
 
   config = lib.mkIf cfg.enable {
-    home.packages = [
-      self.inputs.zen-browser.packages."${pkgs.system}".default
-    ];
+    home.packages = [cfg.package];
   };
 }

--- a/modules/home-manager/desktop/hyprland.nix
+++ b/modules/home-manager/desktop/hyprland.nix
@@ -1,4 +1,4 @@
-self: {
+{
   config,
   lib,
   pkgs,
@@ -12,7 +12,7 @@ self: {
     (builtins.readFile ../../../dotfiles/hyprland/import_env.sh);
 in {
   imports = [
-    (import ./apps/default.nix self)
+    ./apps/default.nix
     ./waybar.nix
     ./hyprland/hypridle.nix
     ./hyprland/hyprlock.nix

--- a/modules/home-manager/sc-im.nix
+++ b/modules/home-manager/sc-im.nix
@@ -11,13 +11,6 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
-    # FIXME Update the system to NixOs 24.05, then switch to stable packages.
-    #
-    # SC-IM has an optional dependency on `libxls`, which is marked as insecure.
-    # Neither I care for this feature.
-    #
-    # Im still on v23.11, but starting from 24.05, `sc-im` Xlsx support was made
-    # optional and disabled by default.
-    home.packages = [pkgs-unstable.sc-im];
+    home.packages = [pkgs.sc-im];
   };
 }


### PR DESCRIPTION
## Rationale

This repository hosts a library of NixOS and Home Manager modules. Reading other people's flakes I noticed that it's better to leave it up to the user when it comes to provide the necessary inputs.