### PR TITLE
bash: Alias `c` to `clear`

### DIFF
--- a/dotfiles/bash/bashrc
+++ b/dotfiles/bash/bashrc
@@ -2,6 +2,7 @@
 
 _has_command() { command -v "${1}" >/dev/null; }
 
+alias c=clear
 alias g=git
 
 alias cdtmp='cd "$(mktemp -d)"'


### PR DESCRIPTION
CLOSES #108
