### PR TITLE
Fix deprecated `nixfmt-rfc-style` [#146]

### DIFF
--- a/treefmt.nix
+++ b/treefmt.nix
@@ -1,4 +1,4 @@
 _: {
   projectRootFile = "flake.nix";
-  programs.nixfmt-rfc-style.enable = true;
+  programs.nixfmt.enable = true;
 }


### PR DESCRIPTION
CLOSES #146

The old `nixfmt-rfc-style` is deprecated and will change to just
`nixfmt`. Also, I got tired of the warning message.
