### PR TITLE
Install nvim-tresitter dependencies

### DIFF
--- a/modules/home-manager/development/neovim.nix
+++ b/modules/home-manager/development/neovim.nix
@@ -19,11 +19,14 @@ in
       viAlias = true;
       vimAlias = true;
       withPython3 = true;
-      plugins = with pkgs.vimPlugins; [
-      ];
+
+      # These packages are only made available to the Neovim wrapper.
       extraPackages = with pkgs; [
         # Test this by running `:checkhealth provider` in vim.
         (python3.withPackages (python-packages: [ python-packages.pynvim ]))
+
+        gcc # Required by `nvim-treesitter` to build parsers.
+        tree-sitter # Required by `nvim-treesitter` to build parsers.
       ];
     };
   };


### PR DESCRIPTION
Adds the packages required by `nvim-treesitter` to build parsers on
install. The packages in question are the _tree-sitter_ CLI and _GCC_.
Instead of installing them globally, it adds them to the environment
of the Neovim wrapper.
