### PR TITLE
[feat] Wayland wallpapers with auto-refresh

### DIFF
--- a/modules/features/desktop/wallpaper.nix
+++ b/modules/features/desktop/wallpaper.nix
@@ -1,6 +1,11 @@
 {
   flake.modules.homeManager.wallpaper =
-    { lib, pkgs, ... }:
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
     {
       systemd.user.services.swaybg = {
         Unit = {
@@ -10,7 +15,7 @@
         };
 
         Service = {
-          ExecStart = "${lib.getExe pkgs.swaybg} -i %h/images/wallpapers/wallpaper";
+          ExecStart = "${lib.getExe pkgs.swaybg} -i ${config.xdg.configHome}/wallpapers/wallpaper";
           Restart = "on-failure";
         };
 

--- a/modules/features/desktop/wallpaper.nix
+++ b/modules/features/desktop/wallpaper.nix
@@ -7,7 +7,7 @@
       ...
     }:
     let
-      wallpapersConfigHome = "${config.xdg.configHome}/wallpapers";
+      wallpapersConfigHome = "${config.xdg.configHome}/wallpaper";
     in
     {
       systemd.user.services.swaybg = {
@@ -18,7 +18,7 @@
         };
 
         Service = {
-          ExecStart = "${lib.getExe pkgs.swaybg} -i ${wallpapersConfigHome}/wallpaper";
+          ExecStart = "${lib.getExe pkgs.swaybg} -i ${wallpapersConfigHome}/current";
           Restart = "on-failure";
         };
 

--- a/modules/features/desktop/wallpaper.nix
+++ b/modules/features/desktop/wallpaper.nix
@@ -9,7 +9,6 @@
     let
       target = "graphical-session.target";
       wallpapersConfigHome = "${config.xdg.configHome}/wallpaper";
-      currentWallpaperFilePath = "${wallpapersConfigHome}/current";
     in
     {
       systemd.user.services.swaybg = {
@@ -20,7 +19,7 @@
         };
 
         Service = {
-          ExecStart = "${lib.getExe pkgs.swaybg} -i ${currentWallpaperFilePath}";
+          ExecStart = "${lib.getExe pkgs.swaybg} -i ${wallpapersConfigHome}/current";
           Restart = "on-failure";
         };
 
@@ -37,7 +36,14 @@
         };
 
         Path = {
-          PathChanged = currentWallpaperFilePath; # Works both on file change and creation.
+          # NOTE: Prefer `PathChanged` over `PathModified` because it will only
+          # trigger after the file is closed. Using `PathModified` can led to
+          # bursts of unnecessary restarts.
+          # NOTE: I'm monitoring the directory here because symlink redirection
+          # didn't work when I monitored the file directly. This is intended as
+          # a single file directory, so there should be no problems unless I
+          # start piling more crap there.
+          PathChanged = wallpapersConfigHome;
           Unit = "refresh-wallpaper.service";
         };
 

--- a/modules/features/desktop/wallpaper.nix
+++ b/modules/features/desktop/wallpaper.nix
@@ -7,23 +7,53 @@
       ...
     }:
     let
+      target = "graphical-session.target";
       wallpapersConfigHome = "${config.xdg.configHome}/wallpaper";
+      currentWallpaperFilePath = "${wallpapersConfigHome}/current";
     in
     {
       systemd.user.services.swaybg = {
         Unit = {
           Description = "Set wallpaper with swaybg";
-          PartOf = [ "graphical-session.target" ];
-          After = [ "graphical-session.target" ];
+          PartOf = [ target ];
+          After = [ target ];
         };
 
         Service = {
-          ExecStart = "${lib.getExe pkgs.swaybg} -i ${wallpapersConfigHome}/current";
+          ExecStart = "${lib.getExe pkgs.swaybg} -i ${currentWallpaperFilePath}";
           Restart = "on-failure";
         };
 
         Install = {
-          WantedBy = [ "graphical-session.target" ];
+          WantedBy = [ target ];
+        };
+      };
+
+      systemd.user.paths.swaybg-wallpaper-watch = {
+        Unit = {
+          Description = "Watch wallpaper file for changes";
+          PartOf = [ target ]; # Ties lifecycle to `graphical-session`.
+          After = [ target ]; # Defers start until `graphical-session` is active.
+        };
+
+        Path = {
+          PathChanged = currentWallpaperFilePath; # Works both on file change and creation.
+          Unit = "refresh-wallpaper.service";
+        };
+
+        Install = {
+          WantedBy = [ target ];
+        };
+      };
+
+      systemd.user.services.refresh-wallpaper = {
+        Unit = {
+          Description = "Restart swaybg when wallpaper file changes";
+        };
+
+        Service = {
+          Type = "oneshot";
+          ExecStart = "${lib.getExe' pkgs.systemd "systemctl"} --user restart swaybg.service";
         };
       };
 

--- a/modules/features/desktop/wallpaper.nix
+++ b/modules/features/desktop/wallpaper.nix
@@ -17,55 +17,59 @@
       wallpapersConfigHome = "${config.xdg.configHome}/wallpaper";
     in
     {
-      systemd.user.services.wallpaper = {
-        Unit = {
-          Description = "Renders desktop wallpaper";
-          PartOf = [ target ];
-          After = [ target ];
+      systemd.user = {
+        paths.wallpaper-file = {
+          Unit = {
+            Description = "Watch wallpaper file for changes";
+            PartOf = [ target ]; # Ties lifecycle to `graphical-session`.
+            After = [ target ]; # Defers start until `graphical-session` is active.
+          };
+
+          Path = {
+            # NOTE: Prefer `PathChanged` over `PathModified` because it will only
+            # trigger after the file is closed. Using `PathModified` can led to
+            # bursts of unnecessary restarts.
+            # NOTE: I'm monitoring the directory here because symlink redirection
+            # didn't work when I monitored the file directly. This is intended as
+            # a single file directory, so there should be no problems unless I
+            # start piling more crap there.
+            PathChanged = wallpapersConfigHome;
+            Unit = "refresh-wallpaper.service";
+          };
+
+          Install = {
+            WantedBy = [ target ];
+          };
         };
 
-        Service = {
-          ExecStart = "${lib.getExe pkgs.swaybg} -i ${wallpapersConfigHome}/current";
-          Restart = "on-failure";
-        };
+        services = {
+          wallpaper = {
+            Unit = {
+              Description = "Renders desktop wallpaper";
+              PartOf = [ target ];
+              After = [ target ];
+            };
 
-        Install = {
-          WantedBy = [ target ];
-        };
-      };
+            Service = {
+              ExecStart = "${lib.getExe pkgs.swaybg} -i ${wallpapersConfigHome}/current";
+              Restart = "on-failure";
+            };
 
-      systemd.user.paths.wallpaper-file = {
-        Unit = {
-          Description = "Watch wallpaper file for changes";
-          PartOf = [ target ]; # Ties lifecycle to `graphical-session`.
-          After = [ target ]; # Defers start until `graphical-session` is active.
-        };
+            Install = {
+              WantedBy = [ target ];
+            };
+          };
 
-        Path = {
-          # NOTE: Prefer `PathChanged` over `PathModified` because it will only
-          # trigger after the file is closed. Using `PathModified` can led to
-          # bursts of unnecessary restarts.
-          # NOTE: I'm monitoring the directory here because symlink redirection
-          # didn't work when I monitored the file directly. This is intended as
-          # a single file directory, so there should be no problems unless I
-          # start piling more crap there.
-          PathChanged = wallpapersConfigHome;
-          Unit = "refresh-wallpaper.service";
-        };
+          refresh-wallpaper = {
+            Unit = {
+              Description = "Refresh wallpaper service when wallpaper file changes";
+            };
 
-        Install = {
-          WantedBy = [ target ];
-        };
-      };
-
-      systemd.user.services.refresh-wallpaper = {
-        Unit = {
-          Description = "Refresh wallpaper service when wallpaper file changes";
-        };
-
-        Service = {
-          Type = "oneshot";
-          ExecStart = "${lib.getExe' pkgs.systemd "systemctl"} --user restart wallpaper.service";
+            Service = {
+              Type = "oneshot";
+              ExecStart = "${lib.getExe' pkgs.systemd "systemctl"} --user restart wallpaper.service";
+            };
+          };
         };
       };
 

--- a/modules/features/desktop/wallpaper.nix
+++ b/modules/features/desktop/wallpaper.nix
@@ -11,9 +11,9 @@
       wallpapersConfigHome = "${config.xdg.configHome}/wallpaper";
     in
     {
-      systemd.user.services.swaybg = {
+      systemd.user.services.wallpaper = {
         Unit = {
-          Description = "Set wallpaper with swaybg";
+          Description = "Renders desktop wallpaper";
           PartOf = [ target ];
           After = [ target ];
         };
@@ -28,7 +28,7 @@
         };
       };
 
-      systemd.user.paths.swaybg-wallpaper-watch = {
+      systemd.user.paths.wallpaper-file = {
         Unit = {
           Description = "Watch wallpaper file for changes";
           PartOf = [ target ]; # Ties lifecycle to `graphical-session`.
@@ -54,12 +54,12 @@
 
       systemd.user.services.refresh-wallpaper = {
         Unit = {
-          Description = "Restart swaybg when wallpaper file changes";
+          Description = "Refresh wallpaper service when wallpaper file changes";
         };
 
         Service = {
           Type = "oneshot";
-          ExecStart = "${lib.getExe' pkgs.systemd "systemctl"} --user restart swaybg.service";
+          ExecStart = "${lib.getExe' pkgs.systemd "systemctl"} --user restart wallpaper.service";
         };
       };
 

--- a/modules/features/desktop/wallpaper.nix
+++ b/modules/features/desktop/wallpaper.nix
@@ -6,6 +6,9 @@
       pkgs,
       ...
     }:
+    let
+      wallpapersConfigHome = "${config.xdg.configHome}/wallpapers";
+    in
     {
       systemd.user.services.swaybg = {
         Unit = {
@@ -15,13 +18,19 @@
         };
 
         Service = {
-          ExecStart = "${lib.getExe pkgs.swaybg} -i ${config.xdg.configHome}/wallpapers/wallpaper";
+          ExecStart = "${lib.getExe pkgs.swaybg} -i ${wallpapersConfigHome}/wallpaper";
           Restart = "on-failure";
         };
 
         Install = {
           WantedBy = [ "graphical-session.target" ];
         };
+      };
+
+      home.activation = {
+        createWallpapersConfigHome = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+          $DRY_RUN_CMD mkdir -p ${wallpapersConfigHome}
+        '';
       };
     };
 }

--- a/modules/features/desktop/wallpaper.nix
+++ b/modules/features/desktop/wallpaper.nix
@@ -1,3 +1,9 @@
+# This module implements a desktop wallpaper feature with auto-refresh.
+#
+# ## Usage
+#
+# To change wallpaper, modify the file with path
+# `${wallpapersConfigHome}/current`. Hint: Use a symlink to save space.
 {
   flake.modules.homeManager.wallpaper =
     {

--- a/modules/features/desktop/wallpaper.nix
+++ b/modules/features/desktop/wallpaper.nix
@@ -1,0 +1,22 @@
+{
+  flake.modules.homeManager.wallpaper =
+    { lib, pkgs, ... }:
+    {
+      systemd.user.services.swaybg = {
+        Unit = {
+          Description = "Set wallpaper with swaybg";
+          PartOf = [ "graphical-session.target" ];
+          After = [ "graphical-session.target" ];
+        };
+
+        Service = {
+          ExecStart = "${lib.getExe pkgs.swaybg} -i %h/images/wallpapers/wallpaper";
+          Restart = "on-failure";
+        };
+
+        Install = {
+          WantedBy = [ "graphical-session.target" ];
+        };
+      };
+    };
+}


### PR DESCRIPTION
## Description

This PR implements:

- a service for a wallpaper daemon.
- A file watcher for auto-refreshing the wallpaper on change.

## Usage

To set or change wallpaper, change the file
`$XDG_CONFIG_HOME/wallpaper/current`.

I like to use a symlink:

```
ln -sf "<path-to-wallpaper>" "$XDG_CONFIG_HOME/wallpaper/current"
```
