### PR TITLE
242 Migrate Ghostty to Stylix

### DIFF
--- a/modules/features/aesthetics.nix
+++ b/modules/features/aesthetics.nix
@@ -52,7 +52,6 @@ in
         # corresponding lines:
         targets = {
           fzf.enable = false;
-          ghostty.enable = false;
           hyprland.enable = false;
           hyprlock.enable = false;
           neovim.enable = false;

--- a/modules/features/desktop/apps/terminal-emulator.nix
+++ b/modules/features/desktop/apps/terminal-emulator.nix
@@ -26,41 +26,6 @@
         programs.ghostty = {
           enable = true;
           enableBashIntegration = true;
-
-          settings = {
-            theme = "base16-dark"; # See custom theme declaration below.
-
-            # Changing the system's default font does not automatically update
-            # Ghostty's font. To apply a new font, its name must be updated here.
-            font-family = lib.head config.fonts.fontconfig.defaultFonts.monospace;
-            font-size = 16;
-          };
-
-          themes.base16-dark = with config.colorScheme.palette; {
-            background = base00;
-            foreground = base05;
-            selection-background = base02;
-            selection-foreground = base05;
-            cursor-color = base05;
-            palette = [
-              "0=#${base00}"
-              "1=#${base08}"
-              "2=#${base0B}"
-              "3=#${base0A}"
-              "4=#${base0D}"
-              "5=#${base0E}"
-              "6=#${base0C}"
-              "7=#${base05}"
-              "8=#${base03}"
-              "9=#${base09}"
-              "10=#${base01}"
-              "11=#${base02}"
-              "12=#${base04}"
-              "13=#${base06}"
-              "14=#${base0F}"
-              "15=#${base07}"
-            ];
-          };
         };
 
         home.activation.reload-ghostty-config = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
@@ -68,6 +33,8 @@
             run "${lib.getExe' pkgs.procps "pkill"}" -SIGUSR2 ghostty
           fi
         '';
+
+        stylix.fonts.sizes.terminal = 16;
       };
     };
 }


### PR DESCRIPTION
CLOSES #242

This PR replaces the nix-colors based Ghostty colorscheme with the default
Stylix theme.

This is not a 1:1 replacement. Colors now have a different order and might break
the legibility of some applications. To solve this problem, create a PR enabling
the Stylix module for the broken program.
