### PR TITLE
Waybar: Removes module related to hyprland

### DIFF
--- a/modules/features/desktop/extras/bar/waybar/modules.nix
+++ b/modules/features/desktop/extras/bar/waybar/modules.nix
@@ -8,7 +8,6 @@
     }:
     {
       programs.waybar.settings.mainBar = {
-        modules-left = [ "hyprland/workspaces" ];
         modules-right = builtins.concatLists [
           [
             "cpu"


### PR DESCRIPTION
CLOSES #248
